### PR TITLE
Hl 9/feature/create home UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,11 @@ import { Route, Switch } from 'react-router';
 import Home from './page/Home';
 import MusicDetail from './page/MusicDetail';
 import MusicList from './page/MusicList';
+import './style/app.css';
 
 const App = () => {
   return (
-    <div>
+    <div className="App">
       <Switch>
         <Route path="/" component={Home} exact />
         <Route path="/musiclist/:moodid" component={MusicList} />

--- a/src/asset/moods.js
+++ b/src/asset/moods.js
@@ -1,47 +1,58 @@
-export const moods = [
+const moods = [
   {
+    id: '1',
     moodName_kr: '유쾌한',
     moodName: 'cheerful',
-    color: '',
+    color: 'aqua',
   },
   {
+    id: '2',
     moodName_kr: '음침한',
     moodName: 'gloomy',
-    color: '',
+    color: 'lightslategray',
   },
   {
+    id: '3',
     moodName_kr: '익살스러운',
     moodName: 'humorous',
-    color: '',
+    color: 'deepskyblue',
   },
   {
+    id: '4',
     moodName_kr: '우울한',
     moodName: 'melancholy',
-    color: '',
+    color: 'lightpink',
   },
   {
+    id: '5',
     moodName_kr: '로맨틱한',
     moodName: 'romantic',
-    color: '',
+    color: 'salmon',
   },
   {
+    id: '6',
     moodName_kr: '신비한',
     moodName: 'mysterious',
-    color: '',
+    color: 'radial-gradient(black, transparent)',
   },
   {
+    id: '7',
     moodName_kr: '차분한',
     moodName: 'calm',
-    color: '',
+    color: 'aquamarine',
   },
   {
+    id: '8',
     moodName_kr: '희망적인',
     moodName: 'hopeful',
-    color: '',
+    color: 'lightsalmon',
   },
   {
+    id: '9',
     moodName_kr: '외로운',
     moodName: 'lonely',
-    color: '',
+    color: 'lemonchiffon',
   },
 ];
+
+export default moods;

--- a/src/asset/moods.js
+++ b/src/asset/moods.js
@@ -1,0 +1,47 @@
+export const moods = [
+  {
+    moodName_kr: '유쾌한',
+    moodName: 'cheerful',
+    color: '',
+  },
+  {
+    moodName_kr: '음침한',
+    moodName: 'gloomy',
+    color: '',
+  },
+  {
+    moodName_kr: '익살스러운',
+    moodName: 'humorous',
+    color: '',
+  },
+  {
+    moodName_kr: '우울한',
+    moodName: 'melancholy',
+    color: '',
+  },
+  {
+    moodName_kr: '로맨틱한',
+    moodName: 'romantic',
+    color: '',
+  },
+  {
+    moodName_kr: '신비한',
+    moodName: 'mysterious',
+    color: '',
+  },
+  {
+    moodName_kr: '차분한',
+    moodName: 'calm',
+    color: '',
+  },
+  {
+    moodName_kr: '희망적인',
+    moodName: 'hopeful',
+    color: '',
+  },
+  {
+    moodName_kr: '외로운',
+    moodName: 'lonely',
+    color: '',
+  },
+];

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const Header = () => {
+  return (
+    <div className="header">
+      <h1>Honey Lyrics</h1>
+      <img
+        src="https://cdn-store.leagueoflegends.co.kr/images/v2/emotes/3153.png"
+        alt="Happy_Bee"
+      />
+    </div>
+  );
+};
+
+export default Header;

--- a/src/components/MoodList.js
+++ b/src/components/MoodList.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import moods from '../asset/moods';
+
+const MoodList = () => {
+  return (
+    <div className="mood-container">
+      {moods.map((mood, index) => (
+        <div
+          key={mood.id}
+          className="mood-item"
+          style={{ background: mood.color }}
+        >
+          <div className="mood-name">{mood.moodName}</div>
+          <div className="short-desc">short description</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MoodList;

--- a/src/components/Searchbar.js
+++ b/src/components/Searchbar.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const Searchbar = () => {
+  return (
+    <div className="searchbar">
+      <input type="text" />
+      <button>
+        <svg viewBox="0 0 24 24">
+          <g>
+            <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
+          </g>
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default Searchbar;

--- a/src/page/Home.js
+++ b/src/page/Home.js
@@ -1,7 +1,16 @@
 import React from 'react';
+import Header from '../components/Header';
+import Searchbar from '../components/Searchbar';
+import MoodList from '../components/MoodList';
 
 const Home = () => {
-  return <div>home</div>;
+  return (
+    <div>
+      <Header />
+      <Searchbar />
+      <MoodList />
+    </div>
+  );
 };
 
 export default Home;

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -1,0 +1,66 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}
+
+.header {
+  display: flex;
+  justify-content: center;
+  font-size: 2rem;
+}
+
+.header img {
+  width: 100px;
+  object-fit: contain;
+}
+
+.searchbar {
+  display: flex;
+  justify-content: center;
+}
+
+.searchbar input {
+  width: 250px;
+  margin-right: 5px;
+}
+
+.searchbar button {
+  width: 35px;
+}
+
+.mood-container {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin: 0 10%;
+}
+
+.mood-item {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  width: 18rem;
+  height: 9rem;
+  margin: 1rem 1rem 0 1rem;
+}
+
+.mood-item .mood-name {
+  font-size: 35px;
+  color: white;
+  font-style: italic;
+  text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+}
+
+.mood-item .short-desc {
+  font-size: 12px;
+}


### PR DESCRIPTION
화면 메인페이지인 Home 컴포넌트의 기본 UI 작성
- Header, Searchbar, Moodlist로 나뉘어져 있습니다.
- Header
  - 헤더의 이미지는 게임 리그오브레전드의 '행복했꿀벌'이미지를 가져왔습니다.(추후 변경 예정)
- Searchbar
  - 검색 아이콘은 유튜브의 svg태그를 가져왔습니다.
- Moodlist
  - 총 9가지의 기분을 임의로 설정하였고 (추후 변경 예정)
  - 각 기분별 색깔도 임의로 설정하였습니다